### PR TITLE
Configuration file updates

### DIFF
--- a/usr/sbin/puppetdb-node-events
+++ b/usr/sbin/puppetdb-node-events
@@ -4,10 +4,7 @@
 ### Configuration #######################################################
 #########################################################################
 
-server = 'http://cmspuppetdb1.fnal.gov:8080'
-nodes_url = '%s/v2/nodes' % server
-facts_url = '%s/v2/facts' % server
-report_url = '%s/v3/events' % server
+config_file = '/etc/puppetdb/puppetdb.json'
 
 output_string = "%-25s %s: %s"
 
@@ -24,6 +21,24 @@ import json, optparse, requests, sys
 #########################################################################
 ### Subroutines #########################################################
 #########################################################################
+
+def parseConfig(file):
+    """
+    Load a json configuration from a configuration file.  Sets a global
+    'config' variable.
+    """
+    global config
+
+    try:
+        config = json.load(open(config_file, 'r'))
+    except IOError, e:
+        print "file error:  %s" % e
+        sys.exit (2)
+    except Exception, e:
+        print "unknown error:  %s" % e
+        sys.exit (2)
+
+    return config
 
 def timestamp_from_time(time):
     """
@@ -54,15 +69,24 @@ def hours_ago(hours):
 
 def main():
     usage = "%prog [options] [HOSTPATTERN]"
+    parseConfig(config_file)
+
+    global p
     p = optparse.OptionParser (usage = usage,
         description = "query puppetdb for facts from matching hosts")
+    p.add_option ('--server', dest='server', default=config['server'],
+        help="puppetdb server (default: %default)")
+    p.add_option ('--events_url_base', dest='events_url_base',
+        default=config['events_url_base'],
+        help="relative URL to puppetdb for default node query")
     p.add_option ('--debug', dest='debug', action='store_true')
     p.add_option ('--hours', dest='hours', default=hours, type='int',
         help='how many hours of reports?  default: %default')
 
+    global opt
     opt, args = p.parse_args()
 
-    if len(args) < 1: 
+    if len(args) < 1:
         p.print_help()
         sys.exit(-1)
     else:
@@ -82,7 +106,8 @@ def main():
 
     headers = {'Accept': 'application/json'}
     try:
-        r = requests.get(report_url, headers=headers, params=payload, verify=False)
+        events_url = "%s%s" % (opt.server, opt.events_url_base)
+        r = requests.get(events_url, headers=headers, params=payload, verify=False)
     except Exception, e:
         p.error('%s (bad json?: %s)' % (e, payload))
 
@@ -102,7 +127,7 @@ def main():
             status = node['status']
             ts = time_from_timestamp(node['timestamp'])
 
-            
+
             string = "%s  %s[%s]: %s -> %s (%s)" % (ts, type, title, old, new, status)
             output.append(string)
             if opt.debug:
@@ -153,7 +178,7 @@ that have occurred on the given host.
 =item I<HOSTPATTERN>
 
 Default host pattern to match.  No default; you will want to list a single
-fqdn, likely.  
+fqdn, likely.
 
 =item --debug
 

--- a/usr/sbin/puppetdb-node-facts
+++ b/usr/sbin/puppetdb-node-facts
@@ -4,9 +4,7 @@
 ### Configuration #######################################################
 #########################################################################
 
-server = 'http://cmspuppetdb1.fnal.gov:8080'
-nodes_url = '%s/v2/nodes' % server
-facts_url = '%s/v2/facts' % server
+config_file = '/etc/puppetdb/puppetdb.json'
 
 output_string = "%-25s %s: %s"
 
@@ -22,10 +20,29 @@ import json, optparse, requests, sys
 ### Subroutines #########################################################
 #########################################################################
 
+def parseConfig(file):
+    """
+    Load a json configuration from a configuration file.  Sets a global
+    'config' variable.
+    """
+    global config
+
+    try:
+        config = json.load(open(config_file, 'r'))
+    except IOError, e:
+        print "file error:  %s" % e
+        sys.exit (2)
+    except Exception, e:
+        print "unknown error:  %s" % e
+        sys.exit (2)
+
+    return config
+
 def node_facts(node):
     """
     """
 
+    nodes_url = "%s%s" % (opt.server, opt.nodes_url_base)
     url = "%s/%s/facts" % (nodes_url, node)
     headers = { 'Accept': 'application/json' }
 
@@ -39,7 +56,7 @@ def node_facts(node):
     for fact in r.json():
         name = fact['name']
         facts[name] = fact['value']
-    
+
     return facts
 
 #########################################################################
@@ -48,9 +65,18 @@ def node_facts(node):
 
 def main():
     usage = "%prog [options] [HOSTPATTERN]"
+    parseConfig(config_file)
+
+    global p
     p = optparse.OptionParser (usage = usage,
         description = "query puppetdb for facts from matching hosts")
+    p.add_option ('--server', dest='server', default=config['server'],
+        help="puppetdb server (default: %default)")
+    p.add_option ('--nodes_url_base', dest='nodes_url_base',
+        default=config['nodes_url_base'],
+        help="relative URL to puppetdb for default node query")
 
+    global opt
     opt, args = p.parse_args()
 
     if len(args) < 1: host_search = '.*'
@@ -64,6 +90,7 @@ def main():
 
     headers = {'Accept': 'application/json'}
     try:
+        nodes_url = "%s%s" % (opt.server, opt.nodes_url_base)
         r = requests.get(nodes_url, headers=headers, params=payload, verify=False)
     except Exception, e:
         p.error('%s (bad json?: %s)' % (e, payload))

--- a/usr/sbin/puppetdb-node-resources
+++ b/usr/sbin/puppetdb-node-resources
@@ -4,9 +4,7 @@
 ### Configuration #######################################################
 #########################################################################
 
-server = 'http://cmspuppetdb1.fnal.gov:8080'
-nodes_url     = '%s/v2/nodes' % server
-resources_url = '%s/v2/resources' % server
+config_file = '/etc/puppetdb/puppetdb.json'
 
 output_string = "%-25s %s: %s"
 
@@ -22,10 +20,29 @@ import json, optparse, requests, sys
 ### Subroutines #########################################################
 #########################################################################
 
+def parseConfig(file):
+    """
+    Load a json configuration from a configuration file.  Sets a global
+    'config' variable.
+    """
+    global config
+
+    try:
+        config = json.load(open(config_file, 'r'))
+    except IOError, e:
+        print "file error:  %s" % e
+        sys.exit (2)
+    except Exception, e:
+        print "unknown error:  %s" % e
+        sys.exit (2)
+
+    return config
+
 def node_resources(node, type, title):
     """
     """
 
+    nodes_url = "%s%s" % (opt.server, opt.nodes_url_base)
     url = "%s/%s/resources" % (nodes_url, node)
     if type is not None:
         url = "%s/%s" % (url, type)
@@ -42,7 +59,7 @@ def node_resources(node, type, title):
     resources = []
     for resource in r.json():
         resources.append(resource)
-    
+
     return resources
 
 #########################################################################
@@ -51,12 +68,21 @@ def node_resources(node, type, title):
 
 def main():
     usage = "%prog [options] [HOSTPATTERN [TYPE [TITLE]]"
+    parseConfig(config_file)
+
+    global p
     p = optparse.OptionParser (usage = usage,
         description = "query puppetdb for resources from matching hosts")
+    p.add_option ('--server', dest='server', default=config['server'],
+        help="puppetdb server (default: %default)")
+    p.add_option ('--nodes_url_base', dest='nodes_url_base',
+        default=config['nodes_url_base'],
+        help="relative URL to puppetdb for default node query")
 
+    global opt
     opt, args = p.parse_args()
 
-    if len(args) < 1: 
+    if len(args) < 1:
         p.print_help()
         sys.exit(-1)
     else:             host_search = args[0]
@@ -75,6 +101,7 @@ def main():
 
     headers = {'Accept': 'application/json'}
     try:
+        nodes_url = "%s%s" % (opt.server, opt.nodes_url_base)
         r = requests.get(nodes_url, headers=headers, params=payload, verify=False)
     except Exception, e:
         p.error('%s (bad json?: %s)' % (e, payload))
@@ -133,7 +160,7 @@ B<puppetdb-node-resources> cmssrv167.fnal.gov Package stunnel
 puppetdb-node-resources queries the puppetdb to find resources on matching
 hosts.  The resource information is printed to stdout.
 
-If there are no matching entries for that host, 
+If there are no matching entries for that host,
 
 =head1 OPTIONS
 
@@ -184,7 +211,7 @@ Prints some short help documentation and exits.
 Make this more configurable, instead of putting the server in the local
 script.
 
-It would be nice to have a better 'pretty-print' option.  
+It would be nice to have a better 'pretty-print' option.
 
 It may, perhaps, be good to have searches based on resources instead of
 hostname.

--- a/usr/sbin/puppetdb-tooquiet
+++ b/usr/sbin/puppetdb-tooquiet
@@ -64,7 +64,7 @@ def hostFact(fact):
     headers = {'Accept': 'application/json'}
     try:
         url = "%s%s" % ( config['server'], config['facts_url_base'] )
-        r = requests.get(url, headers=headers, params=payload, 
+        r = requests.get(url, headers=headers, params=payload,
             cert=requestCert(url), verify=False)
     except Exception, e:
         p.error('%s (bad json?: %s)' % (e, payload))
@@ -107,7 +107,7 @@ def node_print(node):
     ts = time_from_timestamp(node['report_timestamp'])
     if ts is False: ts_string = "**no puppetdb records**"
     else:           ts_string = ts.strftime("%Y-%m-%d %H:%M:%S %Z")
-    
+
     if name in roles: role = roles[name]
     else:             role = 'unknown'
 
@@ -156,13 +156,18 @@ def main():
     headers = {'Accept': 'application/json'}
     try:
         nodes_url = "%s%s" % ( config['server'], config['nodes_url_base'] )
-        r = requests.get(nodes_url, headers=headers, params=payload, 
+        r = requests.get(nodes_url, headers=headers, params=payload,
             cert=requestCert(nodes_url), verify=False)
     except Exception, e:
         p.error('%s (bad json?: %s)' % (e, payload))
 
+    if 'role_fact' in config:
+        role_fact = config['role_fact']
+    else:
+        role_fact = 'role'
+
     global roles
-    roles = hostFact('role')
+    roles = hostFact(role_fact)
 
     items = []
     for node in r.json():


### PR DESCRIPTION
Here are a pair of patches.   One has the puppetdb-node\* scripts use the configuration file for server name and URL paths rather than having them hardcoded.  The other makes the fact that you're using for finding the server role be configurable as well, defaulting to the 'role' fact if none is set to preserve existing behavior.  We're using a 'project' fact for the same data locally, so that's useful as a small change to fill out the column.
